### PR TITLE
fix: correct opencode skills installation paths

### DIFF
--- a/bin/ralph
+++ b/bin/ralph
@@ -231,13 +231,13 @@ async function runInstallSkills() {
         ? scope === "global"
           ? path.join(home, ".claude", "skills")
           : path.join(cwd, ".claude", "skills")
-        : agent === "droid"
+          : agent === "droid"
           ? scope === "global"
             ? path.join(home, ".factory", "skills")
             : path.join(cwd, ".factory", "skills")
           : scope === "global"
-            ? path.join(home, ".local", "share", "opencode", "skills")
-            : path.join(cwd, ".opencode", "skills");
+            ? path.join(home, ".config", "opencode", "skill")
+            : path.join(cwd, ".opencode", "skill");
 
   const skillsToInstall = ["commit", "dev-browser", "prd"];
   fs.mkdirSync(targetRoot, { recursive: true });


### PR DESCRIPTION
## Summary
- Fixed opencode skills installation paths to match the official opencode specification
- Changed global path from `~/.local/share/opencode/skills` to `~/.config/opencode/skill`
- Changed local path from `.opencode/skills` to `.opencode/skill`

## Issue
The current implementation installs opencode skills to incorrect locations:
- Global: `~/.local/share/opencode/skills` (incorrect)
- Local: `.opencode/skills` (incorrect)

According to [opencode.ai/docs/skills/](https://opencode.ai/docs/skills/), the correct paths are:
- Global: `~/.config/opencode/skill/<name>/SKILL.md`
- Local: `.opencode/skill/<name>/SKILL.md`

Note the use of `skill` (singular) instead of `skills` (plural).

## Changes
**File: bin/ralph:239-240**
- Updated opencode global path to use `~/.config/opencode/skill`
- Updated opencode local path to use `.opencode/skill`

## Testing
- All existing tests pass
- Verified the fix by reinstalling ralph globally from this branch